### PR TITLE
Moved client.log and session files under /home/ssh-mitm/log.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -181,7 +181,7 @@ function setup_environment {
     # respectively.
     useradd -m -s /bin/bash ssh-mitm
     chmod 0700 ~ssh-mitm
-    mkdir -m 0755 ~ssh-mitm/{bin,etc}
+    mkdir -m 0755 ~ssh-mitm/{bin,etc,log}
     mkdir -m 0700 ~ssh-mitm/tmp
     chown ssh-mitm:ssh-mitm ~ssh-mitm/tmp
 
@@ -208,9 +208,6 @@ function setup_environment {
     # to not be created properly at run-time...).
     mkdir -m 0700 ~ssh-mitm/empty ~ssh-mitm/.ssh
 
-    # Set ownership on the "empty" directory and SSH host keys.
-    chown ssh-mitm:ssh-mitm /home/ssh-mitm/empty /home/ssh-mitm/.ssh /home/ssh-mitm/etc/ssh_host_*key*
-
     # Create the "run.sh" script, then set its permissions.
     cat > ~ssh-mitm/run.sh <<EOF
 #!/bin/bash
@@ -224,6 +221,9 @@ else
 fi
 EOF
     chmod 0755 ~ssh-mitm/run.sh
+
+    # Set ownership of files under /home/ssh-mitm
+    chown -R ssh-mitm:ssh-mitm /home/ssh-mitm
 
     # Install the AppArmor profiles.
     if [[ ! -d /etc/apparmor.d ]]; then

--- a/openssh-7.5p1-mitm.patch
+++ b/openssh-7.5p1-mitm.patch
@@ -554,7 +554,7 @@ diff -ru --new-file -x '*~' -x 'config.*' -x Makefile -x opensshd.init -x survey
 diff -ru --new-file -x '*~' -x 'config.*' -x Makefile -x opensshd.init -x survey.sh -x openssh.xml -x buildpkg.sh -x output.0 -x requests -x traces.0 -x configure openssh-7.5p1/lol.h openssh-7.5p1-mitm/lol.h
 --- openssh-7.5p1/lol.h	1970-01-01 00:00:00.000000000 +0000
 +++ openssh-7.5p1-mitm/lol.h	2019-09-08 23:26:17.143042221 +0000
-@@ -0,0 +1,59 @@
+@@ -0,0 +1,62 @@
 +#ifndef LOL_H
 +#define LOL_H
 +
@@ -576,6 +576,9 @@ diff -ru --new-file -x '*~' -x 'config.*' -x Makefile -x opensshd.init -x survey
 +/* The root path of SSH MITM (default: "/home/ssh-mitm/") */
 +#define MITM_ROOT "/home/" UNPRIVED_MITM_USER "/"
 +
++/* The log path of SSH MITM (default: "/home/ssh-mitm/log/") */
++#define MITM_LOG "/home/" UNPRIVED_MITM_USER "/log/"
++
 +/* The path to the ssh client config. */
 +#define MITM_SSH_CLIENT_CONFIG MITM_ROOT "etc/ssh_config"
 +
@@ -584,7 +587,7 @@ diff -ru --new-file -x '*~' -x 'config.*' -x Makefile -x opensshd.init -x survey
 +
 +/* The path to the client log file. The "ssh" and "sftp" clients' stderr
 + * will go here. */
-+#define MITM_SSH_CLIENT_LOG MITM_ROOT "client.log"
++#define MITM_SSH_CLIENT_LOG MITM_LOG "client.log"
 +
 +/* This is the size of the buffer used to write the password and read host key
 + * fingerprints to/from the client program. */
@@ -1219,12 +1222,12 @@ diff -ru --new-file -x '*~' -x 'config.*' -x Makefile -x opensshd.init -x survey
 +/* Returns a file handle for logging a shell/sftp session.  Set "is_sftp" arg
 + * to 1 to make a log file for SFTP. */
 +void set_session_log(Session *s, unsigned int is_sftp, const char *command) {
-+  char filename[ sizeof(MITM_ROOT) + 32 ] = MITM_ROOT "shell_session_0.txt";
++  char filename[ sizeof(MITM_LOG) + 32 ] = MITM_LOG "shell_session_0.txt";
 +  int num_tries = 0;
 +
 +  s->is_sftp = is_sftp;
 +  if (s->is_sftp)
-+    strlcpy(filename, MITM_ROOT "sftp_session_0.html", sizeof(filename));
++    strlcpy(filename, MITM_LOG "sftp_session_0.html", sizeof(filename));
 +
 +  s->session_log_fd = -1;
 +  while ((num_tries < MAX_LOG_OPEN_TRIES) && (s->session_log_fd < 0)) {
@@ -1240,9 +1243,9 @@ diff -ru --new-file -x '*~' -x 'config.*' -x Makefile -x opensshd.init -x survey
 +     * to the filename prefix so we can try again. */
 +    if (s->session_log_fd < 0) {
 +      if (s->is_sftp)
-+	snprintf(filename, sizeof(filename) - 1, MITM_ROOT "sftp_session_%d.html", num_tries);
++	snprintf(filename, sizeof(filename) - 1, MITM_LOG "sftp_session_%d.html", num_tries);
 +      else
-+	snprintf(filename, sizeof(filename) - 1, MITM_ROOT "shell_session_%d.txt", num_tries);
++	snprintf(filename, sizeof(filename) - 1, MITM_LOG "shell_session_%d.txt", num_tries);
 +    }
 +  }
 +


### PR DESCRIPTION
Changed ownership of all files under /home/ssh-mitm to ssh-mitm:ssh-mitm.

Moved client.log, shell and sftp session files under /home/ssh-mitm/log.
Will allow Docker containers to write these files into a volume mount.